### PR TITLE
Improve error handling for Playwright failures

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -9,6 +9,9 @@
         <input type="text" name="domain" placeholder="example.com" required />
         <button type="submit">Fetch Jobs</button>
     </form>
+    {% if error %}
+    <p style="color: red">{{ error }}</p>
+    {% endif %}
     {% if jobs %}
     <h2>Job URLs</h2>
     <ul>


### PR DESCRIPTION
## Summary
- handle exceptions from Playwright and surface them in the UI
- display error message on the index page

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_684bb5c4d218832eb4c347d600a0f6b2